### PR TITLE
Fix custom weapon crash?

### DIFF
--- a/mod.txt
+++ b/mod.txt
@@ -16,6 +16,7 @@
     { "hook_id" : "lib/network/base/networkpeer", "script_path" : "thirdperson.lua" },
     { "hook_id" : "lib/managers/criminalsmanager", "script_path" : "thirdperson.lua" },
     { "hook_id" : "lib/managers/menumanager", "script_path" : "thirdperson.lua" },
-    { "hook_id" : "lib/managers/group_ai_states/groupaistatebase", "script_path" : "thirdperson.lua" }
+    { "hook_id" : "lib/managers/group_ai_states/groupaistatebase", "script_path" : "thirdperson.lua" },
+    { "hook_id" : "lib/units/beings/player/huskplayerinventory", "script_path" : "thirdperson.lua" }
   ]
 }

--- a/thirdperson.lua
+++ b/thirdperson.lua
@@ -653,3 +653,13 @@ if RequiredScript == "lib/managers/menumanager" then
   end)
   
 end
+
+if RequiredScript == "lib/units/beings/player/huskplayerinventory" then
+	local ThirdPerson_add_unit_by_name = HuskPlayerInventory.add_unit_by_name
+	function HuskPlayerInventory:add_unit_by_name(new_unit_name, ...)
+		if not DB:has(Idstring("unit"), new_unit_name) then
+			new_unit_name = Idstring("units/payday2/weapons/wpn_npc_m4/wpn_npc_m4")
+		end
+		ThirdPerson_add_unit_by_name(self, new_unit_name, ...)
+	end
+end


### PR DESCRIPTION
mods/BeardLib/Hooks/CoreSystem.lua:18: attempt to index local
'unit_name' (a nil value)
SCRIPT STACK
add_unit_by_name() lib/units/beings/player/huskplayerinventory.lua:67
_perform_switch_equipped_weapon()
lib/units/beings/player/huskplayerinventory.lua:31
synch_equipped_weapon()
lib/units/beings/player/huskplayerinventory.lua:20
...